### PR TITLE
feature: add snapshot configuration in EventStore

### DIFF
--- a/demo/blueprint/src/commands/createCounter.ts
+++ b/demo/blueprint/src/commands/createCounter.ts
@@ -1,0 +1,47 @@
+import { v4 as uuid } from 'uuid';
+
+import { tuple } from '@castore/core';
+import { JSONSchemaCommand } from '@castore/json-schema-command';
+
+import { counterEventStore } from '~/counters';
+
+export const createCounterCommand = new JSONSchemaCommand({
+  commandId: 'CREATE_COUNTER',
+  requiredEventStores: tuple(counterEventStore),
+  inputSchema: {
+    type: 'object',
+    properties: {
+      userId: { type: 'string', format: 'uuid' },
+      startCount: { type: 'number' },
+    },
+    required: ['userId', 'startCount'],
+    additionalProperties: false,
+  } as const,
+  outputSchema: {
+    type: 'object',
+    properties: {
+      counterId: { type: 'string', format: 'uuid' },
+    },
+    required: ['counterId'],
+    additionalProperties: false,
+  } as const,
+  handler: async (input, eventStores) => {
+    const { userId, startCount } = input;
+    const [countersStore] = eventStores;
+
+    const counterId = uuid();
+
+    await countersStore.pushEvent({
+      aggregateId: counterId,
+      version: 1,
+      type: 'COUNTER_CREATED',
+      timestamp: new Date().toISOString(),
+      payload: {
+        userId,
+        startCount,
+      },
+    });
+
+    return { counterId };
+  },
+});

--- a/demo/blueprint/src/commands/createUser.ts
+++ b/demo/blueprint/src/commands/createUser.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { tuple } from '@castore/core';
 import { JSONSchemaCommand } from '@castore/json-schema-command';
 
-import { userEventStore, UserStatus } from '~/users';
+import { userEventStore } from '~/users';
 
 export const createUserCommand = new JSONSchemaCommand({
   commandId: 'CREATE_USER',
@@ -43,40 +43,5 @@ export const createUserCommand = new JSONSchemaCommand({
     });
 
     return { userId };
-  },
-});
-
-export const deleteUser = new JSONSchemaCommand({
-  commandId: 'DELETE_USER',
-  requiredEventStores: tuple(userEventStore),
-  inputSchema: {
-    type: 'object',
-    properties: {
-      userId: { type: 'string', format: 'uuid' },
-    },
-    required: ['userId'],
-    additionalProperties: false,
-  } as const,
-  handler: async (input, eventStores) => {
-    const { userId } = input;
-    const [usersStore] = eventStores;
-
-    const { aggregate } = await usersStore.getAggregate(userId);
-
-    if (aggregate === undefined) {
-      throw new Error('User not found');
-    }
-
-    const { version, status } = aggregate;
-    if (status === UserStatus.REMOVED) {
-      throw new Error('User already removed');
-    }
-
-    await usersStore.pushEvent({
-      aggregateId: userId,
-      version: version + 1,
-      type: 'USER_REMOVED',
-      timestamp: new Date().toISOString(),
-    });
   },
 });

--- a/demo/blueprint/src/commands/incrementCounter.ts
+++ b/demo/blueprint/src/commands/incrementCounter.ts
@@ -1,0 +1,49 @@
+import { tuple } from '@castore/core';
+import { JSONSchemaCommand } from '@castore/json-schema-command';
+
+import { counterEventStore, CounterStatus } from '~/counters';
+
+export const incrementCounterCommand = new JSONSchemaCommand({
+  commandId: 'INCREMENT_COUNTER',
+  requiredEventStores: tuple(counterEventStore),
+  inputSchema: {
+    type: 'object',
+    properties: {
+      counterId: { type: 'string', format: 'uuid' },
+    },
+    required: ['counterId'],
+    additionalProperties: false,
+  } as const,
+  outputSchema: {
+    type: 'object',
+    properties: {
+      counterId: { type: 'string', format: 'uuid' },
+    },
+    required: ['counterId'],
+    additionalProperties: false,
+  } as const,
+  handler: async (input, eventStores) => {
+    const { counterId } = input;
+    const [countersStore] = eventStores;
+
+    const { aggregate } = await countersStore.getAggregate(counterId);
+
+    if (aggregate === undefined) {
+      throw new Error('Counter not found');
+    }
+
+    const { version, status } = aggregate;
+    if (status === CounterStatus.REMOVED) {
+      throw new Error('Counter removed');
+    }
+
+    await countersStore.pushEvent({
+      aggregateId: counterId,
+      version: version + 1,
+      type: 'COUNTER_INCREMENTED',
+      timestamp: new Date().toISOString(),
+    });
+
+    return { counterId };
+  },
+});

--- a/demo/blueprint/src/counters/eventStore.ts
+++ b/demo/blueprint/src/counters/eventStore.ts
@@ -17,6 +17,7 @@ export const counterEventStore = new EventStore({
     counterIncrementedEvent,
     counterRemovedEvent,
   ],
+  snapshotInterval: 2,
   reduce: (counterAggregate: CounterAggregate, event): CounterAggregate => {
     const { version, aggregateId } = event;
 

--- a/demo/blueprint/src/index.ts
+++ b/demo/blueprint/src/index.ts
@@ -2,3 +2,5 @@ export * from './counters';
 export * from './users';
 export { createUserCommand } from './commands/createUser';
 export { deleteUserCommand } from './commands/deleteUser';
+export { createCounterCommand } from './commands/createCounter';
+export { incrementCounterCommand } from './commands/incrementCounter';

--- a/demo/blueprint/src/users/eventStore.ts
+++ b/demo/blueprint/src/users/eventStore.ts
@@ -7,6 +7,7 @@ import { userCreatedEvent, userRemovedEvent } from './events';
 export const userEventStore = new EventStore({
   eventStoreId: 'USER',
   eventStoreEvents: [userCreatedEvent, userRemovedEvent],
+  snapshotInterval: 2,
   reduce: (counterAggregate: UserAggregate, event): UserAggregate => {
     const { version, aggregateId } = event;
 

--- a/demo/implementation/functions/createCounter/handler.ts
+++ b/demo/implementation/functions/createCounter/handler.ts
@@ -1,0 +1,16 @@
+import { createCounterCommand } from '@castore/demo-blueprint';
+
+import { counterEventStore } from '~/libs/eventStores/counters';
+import { applyConsoleMiddleware } from '~/libs/middlewares/console';
+
+export const createCounter = async (
+  event: Parameters<typeof createCounterCommand.handler>[0],
+): Promise<void> => {
+  const output = await createCounterCommand.handler(event, [counterEventStore]);
+  console.log('output');
+  console.log(output);
+};
+
+export const main = applyConsoleMiddleware(createCounter, {
+  inputSchema: createCounterCommand.inputSchema,
+});

--- a/demo/implementation/functions/createCounter/handler.ts
+++ b/demo/implementation/functions/createCounter/handler.ts
@@ -6,9 +6,7 @@ import { applyConsoleMiddleware } from '~/libs/middlewares/console';
 export const createCounter = async (
   event: Parameters<typeof createCounterCommand.handler>[0],
 ): Promise<void> => {
-  const output = await createCounterCommand.handler(event, [counterEventStore]);
-  console.log('output');
-  console.log(output);
+  await createCounterCommand.handler(event, [counterEventStore]);
 };
 
 export const main = applyConsoleMiddleware(createCounter, {

--- a/demo/implementation/functions/createCounter/index.ts
+++ b/demo/implementation/functions/createCounter/index.ts
@@ -1,0 +1,5 @@
+import type { AWS } from '@serverless/typescript';
+
+export const createCounter: Exclude<AWS['functions'], undefined>[string] = {
+  handler: 'functions/createCounter/handler.main',
+};

--- a/demo/implementation/functions/createUser/handler.ts
+++ b/demo/implementation/functions/createUser/handler.ts
@@ -6,9 +6,7 @@ import { applyConsoleMiddleware } from '~/libs/middlewares/console';
 export const createUser = async (
   event: Parameters<typeof createUserCommand.handler>[0],
 ): Promise<void> => {
-  const output = await createUserCommand.handler(event, [userEventStore]);
-  console.log('output');
-  console.log(output);
+  await createUserCommand.handler(event, [userEventStore]);
 };
 
 export const main = applyConsoleMiddleware(createUser, {

--- a/demo/implementation/functions/incrementCounter/handler.ts
+++ b/demo/implementation/functions/incrementCounter/handler.ts
@@ -6,11 +6,7 @@ import { applyConsoleMiddleware } from '~/libs/middlewares/console';
 export const incrementCounter = async (
   event: Parameters<typeof incrementCounterCommand.handler>[0],
 ): Promise<void> => {
-  const output = await incrementCounterCommand.handler(event, [
-    counterEventStore,
-  ]);
-  console.log('output');
-  console.log(output);
+  await incrementCounterCommand.handler(event, [counterEventStore]);
 };
 
 export const main = applyConsoleMiddleware(incrementCounter, {

--- a/demo/implementation/functions/incrementCounter/handler.ts
+++ b/demo/implementation/functions/incrementCounter/handler.ts
@@ -1,0 +1,18 @@
+import { incrementCounterCommand } from '@castore/demo-blueprint';
+
+import { counterEventStore } from '~/libs/eventStores/counters';
+import { applyConsoleMiddleware } from '~/libs/middlewares/console';
+
+export const incrementCounter = async (
+  event: Parameters<typeof incrementCounterCommand.handler>[0],
+): Promise<void> => {
+  const output = await incrementCounterCommand.handler(event, [
+    counterEventStore,
+  ]);
+  console.log('output');
+  console.log(output);
+};
+
+export const main = applyConsoleMiddleware(incrementCounter, {
+  inputSchema: incrementCounterCommand.inputSchema,
+});

--- a/demo/implementation/functions/incrementCounter/index.ts
+++ b/demo/implementation/functions/incrementCounter/index.ts
@@ -1,0 +1,5 @@
+import type { AWS } from '@serverless/typescript';
+
+export const incrementCounter: Exclude<AWS['functions'], undefined>[string] = {
+  handler: 'functions/incrementCounter/handler.main',
+};

--- a/demo/implementation/functions/index.ts
+++ b/demo/implementation/functions/index.ts
@@ -1,5 +1,7 @@
+import { createCounter } from './createCounter';
 import { createUser } from './createUser';
 import { deleteUser } from './deleteUser';
+import { incrementCounter } from './incrementCounter';
 import { logAggregateIds } from './logAggregateIds';
 import { logUserEvents } from './logUserEvents';
 
@@ -8,4 +10,6 @@ export const functions = {
   logAggregateIds,
   createUser,
   deleteUser,
+  createCounter,
+  incrementCounter,
 };

--- a/demo/implementation/resources/dynamoDB/counterEventsTable.ts
+++ b/demo/implementation/resources/dynamoDB/counterEventsTable.ts
@@ -1,5 +1,4 @@
 import {
-  EVENT_TABLE_EVENT_TYPE_KEY,
   EVENT_TABLE_INITIAL_EVENT_INDEX_NAME,
   EVENT_TABLE_IS_INITIAL_EVENT_KEY,
   EVENT_TABLE_PK,
@@ -17,7 +16,6 @@ export const CounterEventsTable = {
     AttributeDefinitions: [
       { AttributeName: EVENT_TABLE_PK, AttributeType: 'S' },
       { AttributeName: EVENT_TABLE_SK, AttributeType: 'N' },
-      { AttributeName: EVENT_TABLE_EVENT_TYPE_KEY, AttributeType: 'S' },
       { AttributeName: EVENT_TABLE_TIMESTAMP_KEY, AttributeType: 'S' },
       { AttributeName: EVENT_TABLE_IS_INITIAL_EVENT_KEY, AttributeType: 'N' },
     ],

--- a/demo/implementation/resources/dynamoDB/userEventsTable.ts
+++ b/demo/implementation/resources/dynamoDB/userEventsTable.ts
@@ -1,5 +1,4 @@
 import {
-  EVENT_TABLE_EVENT_TYPE_KEY,
   EVENT_TABLE_INITIAL_EVENT_INDEX_NAME,
   EVENT_TABLE_IS_INITIAL_EVENT_KEY,
   EVENT_TABLE_PK,
@@ -17,7 +16,6 @@ export const UserEventsTable = {
     AttributeDefinitions: [
       { AttributeName: EVENT_TABLE_PK, AttributeType: 'S' },
       { AttributeName: EVENT_TABLE_SK, AttributeType: 'N' },
-      { AttributeName: EVENT_TABLE_EVENT_TYPE_KEY, AttributeType: 'S' },
       { AttributeName: EVENT_TABLE_TIMESTAMP_KEY, AttributeType: 'S' },
       { AttributeName: EVENT_TABLE_IS_INITIAL_EVENT_KEY, AttributeType: 'N' },
     ],

--- a/demo/visualization/src/components/EventStoreSynchronizer.tsx
+++ b/demo/visualization/src/components/EventStoreSynchronizer.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect } from 'react';
 
-import {
-  EventAlreadyExistsError,
-  EventDetail,
-  StorageAdapter,
-} from '@castore/core';
+import { EventAlreadyExistsError, EventDetail } from '@castore/core';
 
 import { dbByEventStoreId, eventStoresById } from '~/services/data';
 
@@ -24,7 +20,7 @@ export const EventStoreSynchronizer = ({
     // /!\ WARNING /!\ This update do not trigger a re-render
     // This is not an issue right now, but may become one in the future
     // To replace by a state in this case
-    eventStore.storageAdapter = new StorageAdapter({
+    eventStore.storageAdapter = {
       // eslint-disable-next-line @typescript-eslint/require-await
       getEvents: async (aggregateId, { maxVersion } = {}) => {
         let events = eventsByAggregateId[aggregateId] ?? [];
@@ -60,11 +56,18 @@ export const EventStoreSynchronizer = ({
           };
         });
       },
-      // eslint-disable-next-line @typescript-eslint/require-await
-      listAggregateIds: async () => ({
-        aggregateIds: Object.keys(eventsByAggregateId),
-      }),
-    });
+      listAggregateIds: () =>
+        new Promise(resolve =>
+          resolve({
+            aggregateIds: Object.keys(eventsByAggregateId),
+          }),
+        ),
+      // We do not implement snapshots in this adapter
+      putSnapshot: () => new Promise(resolve => resolve()),
+      getLastSnapshot: () =>
+        new Promise(resolve => resolve({ snapshot: undefined })),
+      listSnapshots: () => new Promise(resolve => resolve({ snapshots: [] })),
+    };
   }, [eventsByAggregateId, setEventsByAggregateId]);
 
   return <></>;

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -1,0 +1,4 @@
+export * from './aggregateNotFound';
+export * from './eventAlreadyExists';
+export * from './undefinedStorageAdapterError';
+export * from './invalidSnapshotIntervalError';

--- a/packages/core/src/errors/invalidSnapshotIntervalError.ts
+++ b/packages/core/src/errors/invalidSnapshotIntervalError.ts
@@ -1,0 +1,15 @@
+/**
+ * @name InvalidSnapshotIntervalError
+ * @description Error thrown when the snapshot interval value is invalid
+ */
+export class InvalidSnapshotIntervalError extends Error {
+  snapshotInterval: number;
+
+  constructor({ snapshotInterval }: { snapshotInterval: number }) {
+    super(
+      `Invalid snapshot interval value ${snapshotInterval}. It should at least set to 2. `,
+    );
+
+    this.snapshotInterval = snapshotInterval;
+  }
+}

--- a/packages/core/src/eventStore.type.test.ts
+++ b/packages/core/src/eventStore.type.test.ts
@@ -87,6 +87,7 @@ const assertGetAggregateOutput: A.Equals<
     aggregate: CounterAggregate | undefined;
     events: CounterEventsDetails[];
     lastEvent: CounterEventsDetails | undefined;
+    snapshot: CounterAggregate | undefined;
   }>
 > = 1;
 assertGetAggregateOutput;

--- a/packages/core/src/eventStore.util.test.ts
+++ b/packages/core/src/eventStore.util.test.ts
@@ -6,12 +6,18 @@ import { StorageAdapter } from '~/storageAdapter';
 export const pushEventMock = jest.fn();
 export const getEventsMock = jest.fn();
 export const listAggregateIdsMock = jest.fn();
+export const putSnapshotMock = jest.fn();
+export const getLastSnapshotMock = jest.fn();
+export const listSnapshotsMock = jest.fn();
 
-export const mockStorageAdapter = new StorageAdapter({
+export const mockStorageAdapter: StorageAdapter = {
   pushEvent: pushEventMock,
   getEvents: getEventsMock,
   listAggregateIds: listAggregateIdsMock,
-});
+  putSnapshot: putSnapshotMock,
+  getLastSnapshot: getLastSnapshotMock,
+  listSnapshots: listSnapshotsMock,
+};
 
 // Counters
 
@@ -64,21 +70,20 @@ export type CounterAggregate = {
 };
 
 export const counterIdMock = 'counterId';
+export const counterCreatedEventMock: CounterEventsDetails = {
+  aggregateId: counterIdMock,
+  version: 1,
+  type: 'COUNTER_CREATED',
+  timestamp: '2022',
+};
+export const counterIncrementedEventMock: CounterEventsDetails = {
+  aggregateId: counterIdMock,
+  version: 2,
+  type: 'COUNTER_INCREMENTED',
+  timestamp: '2023',
+};
 export const counterEventsMocks: [CounterEventsDetails, CounterEventsDetails] =
-  [
-    {
-      aggregateId: counterIdMock,
-      version: 1,
-      type: 'COUNTER_CREATED',
-      timestamp: '2022',
-    },
-    {
-      aggregateId: counterIdMock,
-      version: 2,
-      type: 'COUNTER_INCREMENTED',
-      timestamp: '2023',
-    },
-  ];
+  [counterCreatedEventMock, counterIncrementedEventMock];
 
 export const countersReducer = (
   counterAggregate: CounterAggregate,
@@ -124,6 +129,7 @@ export const counterEventStore = new EventStore({
   ],
   reduce: countersReducer,
   storageAdapter: mockStorageAdapter,
+  snapshotInterval: 2,
 });
 
 // Users

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@ export { AggregateNotFoundError } from './errors/aggregateNotFound';
 export { EventAlreadyExistsError } from './errors/eventAlreadyExists';
 export { UndefinedStorageAdapterError } from './errors/undefinedStorageAdapterError';
 export { InvalidSnapshotIntervalError } from './errors/invalidSnapshotIntervalError';
-export { StorageAdapter } from './storageAdapter';
+export type { StorageAdapter } from './storageAdapter';
 export type {
   EventsQueryOptions,
   PushEventContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,12 +5,15 @@ export type { EventDetail } from './event/eventDetail';
 export { AggregateNotFoundError } from './errors/aggregateNotFound';
 export { EventAlreadyExistsError } from './errors/eventAlreadyExists';
 export { UndefinedStorageAdapterError } from './errors/undefinedStorageAdapterError';
+export { InvalidSnapshotIntervalError } from './errors/invalidSnapshotIntervalError';
 export { StorageAdapter } from './storageAdapter';
 export type {
   EventsQueryOptions,
   PushEventContext,
   ListAggregateIdsOptions,
   ListAggregateIdsOutput,
+  GetLastSnapshotOptions,
+  ListSnapshotsOptions,
 } from './storageAdapter';
 export { EventStore } from './eventStore';
 export type {

--- a/packages/core/src/storageAdapter.ts
+++ b/packages/core/src/storageAdapter.ts
@@ -1,6 +1,12 @@
 import { EventDetail } from 'event/eventDetail';
 
-export type EventsQueryOptions = { maxVersion?: number };
+import type { Aggregate } from '~/aggregate';
+
+export type EventsQueryOptions = {
+  minVersion?: number;
+  maxVersion?: number;
+};
+
 export type PushEventContext = { eventStoreId?: string };
 
 export type ListAggregateIdsOptions = {
@@ -13,7 +19,18 @@ export type ListAggregateIdsOutput = {
   nextPageToken?: string;
 };
 
-export class StorageAdapter {
+export type GetLastSnapshotOptions = {
+  maxVersion?: number;
+};
+
+export type ListSnapshotsOptions = {
+  minVersion?: number;
+  maxVersion?: number;
+  limit?: number;
+  reverse?: boolean;
+};
+
+export interface StorageAdapter {
   getEvents: (
     aggregateId: string,
     options?: EventsQueryOptions,
@@ -25,26 +42,13 @@ export class StorageAdapter {
   listAggregateIds: (
     options?: ListAggregateIdsOptions,
   ) => Promise<ListAggregateIdsOutput>;
-
-  constructor({
-    getEvents,
-    pushEvent,
-    listAggregateIds,
-  }: {
-    getEvents: (
-      aggregateId: string,
-      options?: EventsQueryOptions,
-    ) => Promise<{ events: EventDetail[] }>;
-    pushEvent: (
-      eventDetail: EventDetail,
-      context: PushEventContext,
-    ) => Promise<void>;
-    listAggregateIds: (
-      options?: ListAggregateIdsOptions,
-    ) => Promise<ListAggregateIdsOutput>;
-  }) {
-    this.getEvents = getEvents;
-    this.pushEvent = pushEvent;
-    this.listAggregateIds = listAggregateIds;
-  }
+  putSnapshot: (aggregate: Aggregate) => Promise<void>;
+  getLastSnapshot: (
+    aggregateId: string,
+    options?: GetLastSnapshotOptions,
+  ) => Promise<{ snapshot: Aggregate | undefined }>;
+  listSnapshots: (
+    aggregateId: string,
+    options?: ListSnapshotsOptions,
+  ) => Promise<{ snapshots: Aggregate[] }>;
 }

--- a/packages/dynamodb-event-storage-adapter/src/dynamoDb.ts
+++ b/packages/dynamodb-event-storage-adapter/src/dynamoDb.ts
@@ -19,7 +19,10 @@ import {
   ListAggregateIdsOptions,
   ListAggregateIdsOutput,
   PushEventContext,
+  GetLastSnapshotOptions,
+  ListSnapshotsOptions,
   StorageAdapter,
+  Aggregate,
 } from '@castore/core';
 
 import {
@@ -45,6 +48,9 @@ export const EVENT_TABLE_METADATA_KEY = 'metadata';
 export const EVENT_TABLE_IS_INITIAL_EVENT_KEY = 'isInitialEvent';
 export const EVENT_TABLE_INITIAL_EVENT_INDEX_NAME = 'initialEvents';
 
+const getSnapshotPKFromAggregateId = (aggregateId: string): string =>
+  `${aggregateId}#snapshot`;
+
 const isConditionalCheckFailedException = (error: Error): boolean =>
   get(error, 'code') === 'ConditionalCheckFailedException';
 
@@ -62,6 +68,16 @@ export class DynamoDbEventStorageAdapter implements StorageAdapter {
     options?: ListAggregateIdsOptions,
   ) => Promise<ListAggregateIdsOutput>;
 
+  putSnapshot: (aggregate: Aggregate) => Promise<void>;
+  getLastSnapshot: (
+    aggregateId: string,
+    options?: GetLastSnapshotOptions,
+  ) => Promise<{ snapshot: Aggregate | undefined }>;
+  listSnapshots: (
+    aggregateId: string,
+    options?: ListSnapshotsOptions,
+  ) => Promise<{ snapshots: Aggregate[] }>;
+
   tableName: string;
   dynamoDbClient: DynamoDBClient;
 
@@ -75,22 +91,33 @@ export class DynamoDbEventStorageAdapter implements StorageAdapter {
     this.tableName = tableName;
     this.dynamoDbClient = dynamoDbClient;
 
-    this.getEvents = async (aggregateId, { maxVersion } = {}) => {
+    // eslint-disable-next-line complexity
+    this.getEvents = async (
+      aggregateId,
+      { minVersion: minVersion, maxVersion } = {},
+    ) => {
       const marshalledEvents: Record<string, AttributeValue>[] = [];
 
       const eventsQueryCommand = new QueryCommand({
         TableName: this.tableName,
         KeyConditionExpression:
           maxVersion !== undefined
-            ? '#aggregateId = :aggregateId and #version <= :maxVersion'
+            ? minVersion !== undefined
+              ? '#aggregateId = :aggregateId and #version between :minVersion and :maxVersion'
+              : '#aggregateId = :aggregateId and #version <= :maxVersion'
+            : minVersion !== undefined
+            ? '#aggregateId = :aggregateId and #version >= :minVersion'
             : '#aggregateId = :aggregateId',
         ExpressionAttributeNames: {
           '#aggregateId': EVENT_TABLE_PK,
-          ...(maxVersion !== undefined ? { '#version': EVENT_TABLE_SK } : {}),
+          ...(maxVersion !== undefined || minVersion !== undefined
+            ? { '#version': EVENT_TABLE_SK }
+            : {}),
         },
         ExpressionAttributeValues: marshaller.marshallItem({
           ':aggregateId': aggregateId,
           ...(maxVersion !== undefined ? { ':maxVersion': maxVersion } : {}),
+          ...(minVersion !== undefined ? { ':minVersion': minVersion } : {}),
         }),
         ConsistentRead: true,
       });
@@ -229,6 +256,84 @@ export class DynamoDbEventStorageAdapter implements StorageAdapter {
         ...(lastEvaluatedKey !== undefined
           ? { nextPageToken: JSON.stringify(parsedNextPageToken) }
           : {}),
+      };
+    };
+
+    this.putSnapshot = async aggregate => {
+      await this.dynamoDbClient.send(
+        new PutItemCommand({
+          TableName: this.tableName,
+          Item: marshaller.marshallItem({
+            aggregateId: getSnapshotPKFromAggregateId(aggregate.aggregateId),
+            version: aggregate.version,
+            aggregate,
+          }),
+        }),
+      );
+    };
+
+    this.getLastSnapshot = async (aggregateId, { maxVersion } = {}) => {
+      const { snapshots } = await this.listSnapshots(aggregateId, {
+        maxVersion,
+        limit: 1,
+        reverse: true,
+      });
+
+      return { snapshot: snapshots[0] };
+    };
+
+    // eslint-disable-next-line complexity
+    this.listSnapshots = async (
+      aggregateId,
+      { minVersion, maxVersion, limit, reverse } = {},
+    ) => {
+      const marshalledSnapshots: Record<string, AttributeValue>[] = [];
+
+      const snapshotsQueryCommand = new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression:
+          maxVersion !== undefined
+            ? minVersion !== undefined
+              ? '#aggregateId = :aggregateId and #version between :minVersion and :maxVersion'
+              : '#aggregateId = :aggregateId and #version <= :maxVersion'
+            : minVersion !== undefined
+            ? '#aggregateId = :aggregateId and #version >= :minVersion'
+            : '#aggregateId = :aggregateId',
+        ExpressionAttributeNames: {
+          '#aggregateId': EVENT_TABLE_PK,
+          ...(maxVersion !== undefined || minVersion !== undefined
+            ? { '#version': EVENT_TABLE_SK }
+            : {}),
+        },
+        ExpressionAttributeValues: marshaller.marshallItem({
+          ':aggregateId': aggregateId,
+          ...(maxVersion !== undefined ? { ':maxVersion': maxVersion } : {}),
+          ...(minVersion !== undefined ? { ':minVersion': minVersion } : {}),
+        }),
+        ScanIndexForward: reverse !== true,
+        ConsistentRead: true,
+        ...(limit !== undefined ? { Limit: limit } : {}),
+      });
+
+      let snapshotsQueryResult = await this.dynamoDbClient.send(
+        snapshotsQueryCommand,
+      );
+      marshalledSnapshots.push(...(snapshotsQueryResult.Items ?? []));
+
+      while (snapshotsQueryResult.LastEvaluatedKey !== undefined) {
+        snapshotsQueryCommand.input.ExclusiveStartKey =
+          snapshotsQueryResult.LastEvaluatedKey;
+        snapshotsQueryResult = await this.dynamoDbClient.send(
+          snapshotsQueryCommand,
+        );
+
+        marshalledSnapshots.push(...(snapshotsQueryResult.Items ?? []));
+      }
+
+      return {
+        snapshots: marshalledSnapshots.map(item =>
+          marshaller.unmarshallItem(item),
+        ) as Aggregate[],
       };
     };
   }

--- a/packages/dynamodb-event-storage-adapter/src/dynamoDb.ts
+++ b/packages/dynamodb-event-storage-adapter/src/dynamoDb.ts
@@ -306,7 +306,7 @@ export class DynamoDbEventStorageAdapter implements StorageAdapter {
             : {}),
         },
         ExpressionAttributeValues: marshaller.marshallItem({
-          ':aggregateId': aggregateId,
+          ':aggregateId': getSnapshotPKFromAggregateId(aggregateId),
           ...(maxVersion !== undefined ? { ':maxVersion': maxVersion } : {}),
           ...(minVersion !== undefined ? { ':minVersion': minVersion } : {}),
         }),
@@ -331,9 +331,9 @@ export class DynamoDbEventStorageAdapter implements StorageAdapter {
       }
 
       return {
-        snapshots: marshalledSnapshots.map(item =>
-          marshaller.unmarshallItem(item),
-        ) as Aggregate[],
+        snapshots: marshalledSnapshots
+          .map(item => marshaller.unmarshallItem(item))
+          .map(item => item.aggregate) as Aggregate[],
       };
     };
   }

--- a/packages/inmemory-event-storage-adapter/src/inMemory.ts
+++ b/packages/inmemory-event-storage-adapter/src/inMemory.ts
@@ -8,6 +8,9 @@ import {
   ListAggregateIdsOutput,
   PushEventContext,
   StorageAdapter,
+  Aggregate,
+  GetLastSnapshotOptions,
+  ListSnapshotsOptions,
 } from '@castore/core';
 
 import {
@@ -42,6 +45,15 @@ export class InMemoryStorageAdapter implements StorageAdapter {
   listAggregateIds: (
     options?: ListAggregateIdsOptions,
   ) => Promise<ListAggregateIdsOutput>;
+  putSnapshot: (aggregate: Aggregate) => Promise<void>;
+  getLastSnapshot: (
+    aggregateId: string,
+    options?: GetLastSnapshotOptions,
+  ) => Promise<{ snapshot: Aggregate | undefined }>;
+  listSnapshots: (
+    aggregateId: string,
+    options?: ListSnapshotsOptions,
+  ) => Promise<{ snapshots: Aggregate[] }>;
 
   eventStore: { [aggregateId: string]: EventDetail[] };
 
@@ -130,5 +142,12 @@ export class InMemoryStorageAdapter implements StorageAdapter {
           : {}),
       };
     };
+
+    // We do not implement snapshots in this adapter
+    this.putSnapshot = () => new Promise(resolve => resolve());
+    this.getLastSnapshot = () =>
+      new Promise(resolve => resolve({ snapshot: undefined }));
+    this.listSnapshots = () =>
+      new Promise(resolve => resolve({ snapshots: [] }));
   }
 }

--- a/packages/json-schema-command/src/jsonSchema.unit.test.ts
+++ b/packages/json-schema-command/src/jsonSchema.unit.test.ts
@@ -4,6 +4,7 @@ import {
   counterEventsMocks,
   counterEventStore,
   getEventsMock,
+  getLastSnapshotMock,
   incrementCounter,
   incrementCounterA,
   incrementCounterANoOutput,
@@ -17,6 +18,7 @@ import {
 } from './jsonSchema.util.test';
 
 getEventsMock.mockResolvedValue({ events: counterEventsMocks });
+getLastSnapshotMock.mockResolvedValue({ snapshot: undefined });
 
 describe('jsonSchemaCommand implementation', () => {
   it('has correct properties', () => {

--- a/packages/json-schema-command/src/jsonSchema.util.test.ts
+++ b/packages/json-schema-command/src/jsonSchema.util.test.ts
@@ -12,12 +12,18 @@ import { JSONSchemaCommand } from './jsonSchema';
 export const pushEventMock = jest.fn();
 export const getEventsMock = jest.fn();
 export const listAggregateIdsMock = jest.fn();
+export const putSnapshotMock = jest.fn();
+export const getLastSnapshotMock = jest.fn();
+export const listSnapshotsMock = jest.fn();
 
-export const mockStorageAdapter = new StorageAdapter({
+export const mockStorageAdapter: StorageAdapter = {
   pushEvent: pushEventMock,
   getEvents: getEventsMock,
   listAggregateIds: listAggregateIdsMock,
-});
+  putSnapshot: putSnapshotMock,
+  getLastSnapshot: getLastSnapshotMock,
+  listSnapshots: listSnapshotsMock,
+};
 
 // Counters
 


### PR DESCRIPTION
TODO before merging:

- Check with demo that everything works as expected (add `console.log`s everywhere) !

Then, before next release:
- Add `recomputeSnapshot` method on `EventStore` class.
- Add `reducer` hash in `EventStore` props and store it in snapshots + validate on read that it is still up-to-date (otherwise, recompute snapshot)
- Create `recomputeSnapshots` method on `EventStore` class that iterates on `aggregateIds` and `snapshots`, and recompute them if reducer hash is not up-to-date