### PR TITLE
Align docs with types (eventStore.reduce)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ const userEventStore = new EventStore({
     userRemovedEventType,
     ...
   ],
-  reducer: usersReducer,
+  reduce: usersReducer,
 });
 // ...and that's it 🥳
 ```


### PR DESCRIPTION
# Description 🦫

When playing around with castore over the weekend, I started copy pasting the examples from the readme and realized that the `eventStore.reducer` property has been renamed to `eventStore.reduce`

Refer : https://github.com/castore-dev/castore/blob/main/packages/core/src/eventStore/eventStore.ts#L79

This has actually also being reported before: https://github.com/castore-dev/castore/issues/29

## Type of change 📝

- [x] Updated Documentation

# How Has This Been Tested? 🧑‍🔬

I am using it in my local project.

# Checklist ✅
- [x]  I have performed a self-review of my own code
- [x]  I have made corresponding changes to the documentation
