### PR TITLE
Feat/specify unmarshall options

### DIFF
--- a/demo/blueprint/package.json
+++ b/demo/blueprint/package.json
@@ -20,9 +20,9 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/demo/implementation/package.json
+++ b/demo/implementation/package.json
@@ -12,10 +12,10 @@
     "log": "env-cmd sls logs -t -f",
     "print": "env-cmd sls print",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
-    "test-linter": "yarn linter-base-config ."
+    "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.2.0",

--- a/demo/visualization/package.json
+++ b/demo/visualization/package.json
@@ -7,9 +7,9 @@
     "linter-base-config": "eslint --ext=js,ts",
     "start": "vite",
     "test": "yarn test-type && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
-    "test-linter": "yarn linter-base-config ."
+    "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false"
   },
   "browserslist": {
     "production": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,10 +29,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/dynamodb-event-storage-adapter/package.json
+++ b/packages/dynamodb-event-storage-adapter/package.json
@@ -30,10 +30,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/dynamodb-event-storage-adapter/src/adapter.ts
+++ b/packages/dynamodb-event-storage-adapter/src/adapter.ts
@@ -8,7 +8,11 @@ import {
   DynamoDBClient,
   TransactWriteItemsCommand,
 } from '@aws-sdk/client-dynamodb';
-import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import {
+  marshall,
+  unmarshall,
+  unmarshallOptions as UnmarshallOptionsType,
+} from '@aws-sdk/util-dynamodb';
 
 import {
   Aggregate,
@@ -136,9 +140,11 @@ export class DynamoDbEventStorageAdapter implements StorageAdapter {
   constructor({
     tableName,
     dynamoDbClient,
+    unmarshallOptions,
   }: {
     tableName: string | (() => string);
     dynamoDbClient: DynamoDBClient;
+    unmarshallOptions?: UnmarshallOptionsType;
   }) {
     this.tableName = tableName;
     this.dynamoDbClient = dynamoDbClient;
@@ -198,7 +204,7 @@ export class DynamoDbEventStorageAdapter implements StorageAdapter {
 
       return {
         events: marshalledEvents
-          .map(item => unmarshall(item))
+          .map(item => unmarshall(item, unmarshallOptions))
           .map((item): EventDetail => {
             const {
               aggregateId: evtAggregateId,
@@ -405,7 +411,7 @@ export class DynamoDbEventStorageAdapter implements StorageAdapter {
 
       return {
         aggregateIds: unmarshalledInitialEvents
-          .map(item => unmarshall(item))
+          .map(item => unmarshall(item, unmarshallOptions))
           .map(item => {
             const { aggregateId } = item as Pick<EventDetail, 'aggregateId'>;
 

--- a/packages/dynamodb-event-storage-adapter/src/constants.ts
+++ b/packages/dynamodb-event-storage-adapter/src/constants.ts
@@ -11,6 +11,5 @@ export const EVENT_TABLE_EVENT_STORE_ID_KEY = 'eventStoreId';
 export const EVENT_TABLE_INITIAL_EVENT_INDEX_NAME = 'initialEvents';
 
 export const MARSHALL_OPTIONS: MarshallOptions = {
-  convertEmptyValues: false,
   removeUndefinedValues: true,
 };

--- a/packages/dynamodb-event-storage-adapter/src/singleTableAdapter.ts
+++ b/packages/dynamodb-event-storage-adapter/src/singleTableAdapter.ts
@@ -8,7 +8,11 @@ import {
   DynamoDBClient,
   TransactWriteItemsCommand,
 } from '@aws-sdk/client-dynamodb';
-import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import {
+  marshall,
+  unmarshall,
+  unmarshallOptions as UnmarshallOptionsType,
+} from '@aws-sdk/util-dynamodb';
 
 import {
   Aggregate,
@@ -152,9 +156,11 @@ export class DynamoDbSingleTableEventStorageAdapter implements StorageAdapter {
   constructor({
     tableName,
     dynamoDbClient,
+    unmarshallOptions,
   }: {
     tableName: string | (() => string);
     dynamoDbClient: DynamoDBClient;
+    unmarshallOptions?: UnmarshallOptionsType;
   }) {
     this.tableName = tableName;
     this.dynamoDbClient = dynamoDbClient;
@@ -214,7 +220,7 @@ export class DynamoDbSingleTableEventStorageAdapter implements StorageAdapter {
 
       return {
         events: marshalledEvents
-          .map(item => unmarshall(item))
+          .map(item => unmarshall(item, unmarshallOptions))
           .map((item): EventDetail => {
             const {
               aggregateId: evtAggregateId,
@@ -427,7 +433,7 @@ export class DynamoDbSingleTableEventStorageAdapter implements StorageAdapter {
 
       return {
         aggregateIds: unmarshalledInitialEvents
-          .map(item => unmarshall(item))
+          .map(item => unmarshall(item, unmarshallOptions))
           .map(item => {
             const { aggregateId } = item as Pick<EventDetail, 'aggregateId'>;
 

--- a/packages/event-bridge-message-bus-adapter/package.json
+++ b/packages/event-bridge-message-bus-adapter/package.json
@@ -30,10 +30,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/in-memory-message-bus-adapter/package.json
+++ b/packages/in-memory-message-bus-adapter/package.json
@@ -30,10 +30,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/in-memory-message-queue-adapter/package.json
+++ b/packages/in-memory-message-queue-adapter/package.json
@@ -30,10 +30,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/inmemory-event-storage-adapter/package.json
+++ b/packages/inmemory-event-storage-adapter/package.json
@@ -30,10 +30,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/json-schema-command/package.json
+++ b/packages/json-schema-command/package.json
@@ -30,10 +30,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/json-schema-event/package.json
+++ b/packages/json-schema-event/package.json
@@ -30,10 +30,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/react-visualizer/package.json
+++ b/packages/react-visualizer/package.json
@@ -30,10 +30,10 @@
     "package-esm": "NODE_ENV=esm BABEL_ENV=modern yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts,.tsx --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/redux-event-storage-adapter/package.json
+++ b/packages/redux-event-storage-adapter/package.json
@@ -31,10 +31,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/sqs-message-queue-adapter/package.json
+++ b/packages/sqs-message-queue-adapter/package.json
@@ -30,10 +30,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/test-tools/package.json
+++ b/packages/test-tools/package.json
@@ -30,10 +30,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },

--- a/packages/zod-event/package.json
+++ b/packages/zod-event/package.json
@@ -30,10 +30,10 @@
     "package-esm": "NODE_ENV=esm yarn transpile --out-dir dist/esm --source-maps",
     "package-types": "ttsc -p tsconfig.build.json",
     "test": "yarn test-type && yarn test-unit && yarn test-circular && yarn test-linter",
-    "test-type": "tsc --noEmit --emitDeclarationOnly false",
-    "test-unit": "yarn vitest run --passWithNoTests",
     "test-circular": "yarn depcruise --validate dependency-cruiser.js .",
     "test-linter": "yarn linter-base-config .",
+    "test-type": "tsc --noEmit --emitDeclarationOnly false",
+    "test-unit": "yarn vitest run --passWithNoTests",
     "transpile": "babel src --extensions .ts --quiet",
     "watch": "rm -rf dist && concurrently 'yarn:package-* --watch'"
   },


### PR DESCRIPTION
# Description 🦫

By default, the `unmarshall` function of `@aws-sdk/util-dynamodb` uses `convertToNumber` util that [wraps](https://github.com/aws/aws-sdk-js-v3/blob/main/packages/util-dynamodb/src/convertToNative.ts#LL45C1-L47C4) numbers in a [NumberValue](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/interfaces/_aws_sdk_util_dynamodb.NumberValue.html) format to handle all numbers of arbitrary size. 

This is a problem when validating an item (for instance the response of `eventstore.getAggregate()`) against a jsonSchema which expects a `number` type, and rather reads a `NumberValue` type.

## Type of change 📝

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested? 🧑‍🔬

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: 🔧
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist: ✅

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules