### PR TITLE
Allow DynamoDB index and key names to be overridden

### DIFF
--- a/packages/core/src/eventStorageAdapter.ts
+++ b/packages/core/src/eventStorageAdapter.ts
@@ -49,4 +49,9 @@ export interface EventStorageAdapter {
     context: EventStoreContext,
     options?: ListAggregateIdsOptions,
   ) => Promise<ListAggregateIdsOutput>;
+  eventTableEventStoreIdKey?: string;
+  eventTableInitialEventIndexName?: string;
+  eventTablePk?: string;
+  eventTableSk?: string;
+  eventTableTimestampKey?: string;
 }

--- a/packages/event-storage-adapter-dynamodb/README.md
+++ b/packages/event-storage-adapter-dynamodb/README.md
@@ -393,7 +393,7 @@ import {
   "Properties": {
     "AttributeDefinitions": [
       { "AttributeName": "aggregateId", "AttributeType": "S" },
-      { "AttributeName": "version", "AttributeType": "N" }
+      { "AttributeName": "version", "AttributeType": "S" }
       { "AttributeName": "isInitialEvent", "AttributeType": "N" },
       { "AttributeName": "timestamp", "AttributeType": "S" }
     ],
@@ -430,7 +430,7 @@ const pokemonsEventsTable = new Table(scope, 'PokemonEvents', {
   },
   sortKey: {
     name: 'version',
-    type: NUMBER,
+    type: STRING,
   },
 });
 
@@ -462,7 +462,7 @@ resource "aws_dynamodb_table" "pokemons-events-table" {
 
   attribute {
     name = "version"
-    type = "N"
+    type = "S"
   }
 
   attribute {

--- a/packages/event-storage-adapter-dynamodb/README.md
+++ b/packages/event-storage-adapter-dynamodb/README.md
@@ -33,17 +33,22 @@ The legacy `DynamoDBEventStorageAdapter` is still exposed for backward compatibi
 
 Documentation:
 
-- [`DynamoDBSingleTableEventStorageAdapter`](#dynamodbsingletableeventstorageadapter)
-  - [👩‍💻 Usage](#-usage)
-  - [🤔 How it works](#-how-it-works)
-  - [📝 Examples](#-examples)
-    - [CloudFormation](#cloudformation)
-    - [CDK](#cdk)
-    - [Terraform](#terraform)
-  - [🤝 EventGroups](#-eventgroups)
-  - [🔑 IAM](#-iam)
-  - [📸 `ImageParser`](#-imageparser)
-- [`DynamoDBEventStorageAdapter`](#legacy-dynamodbeventstorageadapter)
+- [DynamoDB Event Storage Adapter](#dynamodb-event-storage-adapter)
+  - [📥 Installation](#-installation)
+  - [Table of content](#table-of-content)
+  - [`DynamoDBSingleTableEventStorageAdapter`](#dynamodbsingletableeventstorageadapter)
+    - [👩‍💻 Usage](#-usage)
+    - [🤔 How it works](#-how-it-works)
+    - [📝 Examples](#-examples)
+    - [🤝 EventGroups](#-eventgroups)
+    - [🔑 IAM](#-iam)
+    - [📸 `ImageParser`](#-imageparser)
+  - [Legacy `DynamoDBEventStorageAdapter`](#legacy-dynamodbeventstorageadapter)
+    - [👩‍💻 Usage](#-usage-1)
+    - [🤔 How it works](#-how-it-works-1)
+    - [📝 Examples](#-examples-1)
+    - [🤝 EventGroups](#-eventgroups-1)
+    - [🔑 IAM](#-iam-1)
 
 ## `DynamoDBSingleTableEventStorageAdapter`
 
@@ -115,6 +120,18 @@ By design, the `listAggregateIds` operation can only be **eventually consistent*
 ### 📝 Examples
 
 Note that if you define your infrastructure as code in TypeScript, you can directly use this package instead of hard-coding the below values:
+
+```ts
+import {
+  EVENT_TABLE_PK, // => aggregateId
+  EVENT_TABLE_SK, // => version
+  EVENT_TABLE_INITIAL_EVENT_INDEX_NAME, // => initialEvents
+  EVENT_TABLE_EVENT_STORE_ID_KEY, // => eventStoreId
+  EVENT_TABLE_TIMESTAMP_KEY, // => timestamp
+} from '@castore/event-storage-adapter-dynamodb';
+```
+
+Alternatively, you can declare your own keys and index name. This is useful if you want to use the Dynamo table for other purposes than Castore:
 
 ```ts
 import {
@@ -300,6 +317,16 @@ const pokemonsEventStorageAdapter = new DynamoDBEventStorageAdapter({
 const pokemonsEventStorageAdapter = new DynamoDBEventStorageAdapter({
   tableName: () => process.env.MY_TABLE_NAME,
   dynamoDBClient,
+});
+
+// 👇 Alternatively, provide keys and index names
+const pokemonsEventStorageAdapter = new DynamoDBEventStorageAdapter({
+  tableName: 'my-table-name',
+  dynamoDBClient,
+  eventTableInitialEventIndexName: "_GSI1";
+  eventTablePk: "_PK";
+  eventTableSk: "_SK";
+  eventTableTimestampKey: "_GSI1_SK";
 });
 
 const pokemonsEventStore = new EventStore({

--- a/packages/event-storage-adapter-dynamodb/src/singleTableAdapter.ts
+++ b/packages/event-storage-adapter-dynamodb/src/singleTableAdapter.ts
@@ -251,7 +251,8 @@ export class DynamoDBSingleTableEventStorageAdapter
               ...(payload !== undefined ? { payload } : {}),
               ...(metadata !== undefined ? { metadata } : {}),
             };
-          }),
+          })
+          .sort((a, b) => a.version - b.version),
       };
     };
 
@@ -269,12 +270,12 @@ export class DynamoDBSingleTableEventStorageAdapter
             type,
             timestamp,
             [this.eventTablePk]: prefixAggregateId(eventStoreId, aggregateId),
-            [this.eventTableSk]: version,
+            [this.eventTableSk]: version.toString(),
             [this.eventTableTimestampKey]: timestamp,
             ...(payload !== undefined ? { payload } : {}),
             ...(metadata !== undefined ? { metadata } : {}),
             ...(version === 1
-              ? { [this.eventTableEventStoreIdKey]: eventStoreId, eventStoreId }
+              ? { eventStoreId, [this.eventTableEventStoreIdKey]: eventStoreId }
               : {}),
           },
           MARSHALL_OPTIONS,

--- a/packages/event-storage-adapter-dynamodb/src/singleTableAdapter.unit.test.ts
+++ b/packages/event-storage-adapter-dynamodb/src/singleTableAdapter.unit.test.ts
@@ -527,3 +527,491 @@ describe('DynamoDBEventStorageAdapter', () => {
     });
   });
 });
+
+describe('DynamoDBEventStorageAdapter with key and index overrides', () => {
+  beforeEach(() => {
+    dynamoDBClientMock.reset();
+    dynamoDBClientMock.on(PutItemCommand).resolves({});
+    dynamoDBClientMock.on(QueryCommand).resolves({});
+  });
+
+  const eventTablePk = '_PK';
+  const eventTableSk = '_SK';
+  const eventTableInitialEventIndexName = '_GSI1';
+  const eventTableEventStoreIdKey = '_GSI1_PK';
+  const eventTableTimestampKey = '_GSI1_SK';
+
+  const savedSecondEventWithCustomKeys = {
+    ...savedSecondEvent,
+    [eventTablePk]: savedSecondEvent.aggregateId,
+    [eventTableSk]: savedSecondEvent.version,
+    [eventTableTimestampKey]: secondEvent.timestamp,
+  };
+
+  const adapter = new DynamoDBSingleTableEventStorageAdapter({
+    tableName: dynamoDBTableName,
+    dynamoDBClient: dynamoDBClientMock as unknown as DynamoDBClient,
+    eventTablePk,
+    eventTableSk,
+    eventTableInitialEventIndexName,
+    eventTableEventStoreIdKey,
+    eventTableTimestampKey,
+  });
+
+  describe('push event', () => {
+    it('sends a correct PutItemCommand to dynamoDBClient to push new event', async () => {
+      await adapter.pushEvent(secondEvent, { eventStoreId });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.calls()).toHaveLength(1);
+      expect(dynamoDBClientMock.call(0).args[0].input).toStrictEqual({
+        ConditionExpression: 'attribute_not_exists(#version)',
+        ExpressionAttributeNames: { '#version': eventTableSk },
+        Item: marshall(savedSecondEventWithCustomKeys, MARSHALL_OPTIONS),
+        TableName: dynamoDBTableName,
+      });
+    });
+
+    it('sends a correct PutItemCommand to dynamoDBClient to push new initial event', async () => {
+      await adapter.pushEvent(initialEvent, { eventStoreId });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.calls()).toHaveLength(1);
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        Item: marshall(savedInitialEvent, MARSHALL_OPTIONS),
+      });
+    });
+
+    it('appends a timestamp if none has been provided', async () => {
+      MockDate.set(timestampA);
+
+      await adapter.pushEvent(omit(secondEvent, 'timestamp'), { eventStoreId });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        Item: marshall({ timestamp: timestampA }, MARSHALL_OPTIONS),
+      });
+
+      MockDate.reset();
+    });
+
+    it('does not add condition if force option is set to true', async () => {
+      await adapter.pushEvent(secondEvent, { eventStoreId, force: true });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.calls()).toHaveLength(1);
+      const input = dynamoDBClientMock.call(0).args[0].input;
+      expect(input).not.toHaveProperty('ConditionExpression');
+      expect(input).not.toHaveProperty('ExpressionAttributeNames');
+    });
+  });
+
+  describe('table name getter', () => {
+    it('works with event bus name getters', async () => {
+      const adapterWithGetter = new DynamoDBSingleTableEventStorageAdapter({
+        tableName: () => dynamoDBTableName,
+        dynamoDBClient: dynamoDBClientMock as unknown as DynamoDBClient,
+      });
+
+      await adapterWithGetter.pushEvent(initialEvent, { eventStoreId });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.calls()).toHaveLength(1);
+    });
+  });
+
+  describe('get events', () => {
+    it('sends a correct QueryCommand to dynamoDBClient to get aggregate events', async () => {
+      const queryCommandOutputMock: QueryCommandOutput = {
+        Items: [
+          marshall(savedInitialEvent, MARSHALL_OPTIONS),
+          marshall(savedSecondEvent, MARSHALL_OPTIONS),
+        ],
+        $metadata: {},
+      };
+
+      dynamoDBClientMock.on(QueryCommand).resolves(queryCommandOutputMock);
+
+      const { events } = await adapter.getEvents(aggregateId, { eventStoreId });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.calls()).toHaveLength(1);
+      expect(dynamoDBClientMock.call(0).args[0].input).toStrictEqual({
+        ConsistentRead: true,
+        ExpressionAttributeNames: { '#aggregateId': eventTablePk },
+        ExpressionAttributeValues: marshall(
+          { ':aggregateId': prefixedAggregateId },
+          MARSHALL_OPTIONS,
+        ),
+        KeyConditionExpression: '#aggregateId = :aggregateId',
+        TableName: dynamoDBTableName,
+      });
+
+      // We have to serialize / deserialize because DynamoDB numbers are not regular numbers
+      expect(JSON.parse(JSON.stringify(events))).toMatchObject([
+        initialEvent,
+        secondEvent,
+      ]);
+    });
+
+    it('repeats queries if it is paginated', async () => {
+      const lastEvaluatedKey = marshall(initialEvent, MARSHALL_OPTIONS);
+
+      const firstQueryCommandOutputMock: QueryCommandOutput = {
+        Items: [marshall(savedInitialEvent, MARSHALL_OPTIONS)],
+        $metadata: {},
+        LastEvaluatedKey: lastEvaluatedKey,
+      };
+      const secondQueryCommandOutputMock: QueryCommandOutput = {
+        Items: [marshall(savedSecondEvent, MARSHALL_OPTIONS)],
+        $metadata: {},
+      };
+
+      dynamoDBClientMock
+        .on(QueryCommand)
+        .resolvesOnce(firstQueryCommandOutputMock)
+        .resolvesOnce(secondQueryCommandOutputMock);
+
+      const { events } = await adapter.getEvents(aggregateId, { eventStoreId });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.calls()).toHaveLength(2);
+      expect(dynamoDBClientMock.call(1).args[0].input).toMatchObject({
+        ExclusiveStartKey: lastEvaluatedKey,
+      });
+
+      // We have to serialize / deserialize because DynamoDB numbers are not regular numbers
+      expect(JSON.parse(JSON.stringify(events))).toMatchObject([
+        initialEvent,
+        secondEvent,
+      ]);
+    });
+
+    it('fetches events in reverse', async () => {
+      await adapter.getEvents(aggregateId, { eventStoreId }, { reverse: true });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        ScanIndexForward: false,
+      });
+    });
+
+    it('adds min version', async () => {
+      await adapter.getEvents(aggregateId, { eventStoreId }, { minVersion: 3 });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        ExpressionAttributeNames: { '#version': eventTableSk },
+        ExpressionAttributeValues: marshall(
+          { ':minVersion': 3 },
+          MARSHALL_OPTIONS,
+        ),
+        KeyConditionExpression:
+          '#aggregateId = :aggregateId and #version >= :minVersion',
+      });
+    });
+
+    it('adds max version', async () => {
+      await adapter.getEvents(aggregateId, { eventStoreId }, { maxVersion: 5 });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        ExpressionAttributeNames: { '#version': eventTableSk },
+        ExpressionAttributeValues: marshall(
+          { ':maxVersion': 5 },
+          MARSHALL_OPTIONS,
+        ),
+        KeyConditionExpression:
+          '#aggregateId = :aggregateId and #version <= :maxVersion',
+      });
+    });
+
+    it('adds min & max versions', async () => {
+      await adapter.getEvents(
+        aggregateId,
+        { eventStoreId },
+        { minVersion: 3, maxVersion: 5 },
+      );
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        ExpressionAttributeNames: { '#version': eventTableSk },
+        ExpressionAttributeValues: marshall(
+          { ':minVersion': 3, ':maxVersion': 5 },
+          MARSHALL_OPTIONS,
+        ),
+        KeyConditionExpression:
+          '#aggregateId = :aggregateId and #version between :minVersion and :maxVersion',
+      });
+    });
+
+    it('adds limit', async () => {
+      await adapter.getEvents(aggregateId, { eventStoreId }, { limit: 2 });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        Limit: 2,
+      });
+    });
+  });
+
+  describe('list aggregate ids', () => {
+    const lastEvaluatedKey = marshall(
+      {
+        aggregateId: prefixedAggregateId,
+        version: 1,
+        eventStoreId,
+        timestamp: timestampA,
+      },
+      MARSHALL_OPTIONS,
+    );
+
+    it('sends a correct QueryCommand to dynamoDBClient to list aggregate ids', async () => {
+      const secondAggregateIdMock = 'my-second-aggregate-id';
+      const queryCommandOutputMock: QueryCommandOutput = {
+        Items: [
+          marshall({ aggregateId: prefixedAggregateId, timestamp: timestampA }),
+          marshall({
+            aggregateId: prefixAggregateId(eventStoreId, secondAggregateIdMock),
+            timestamp: timestampB,
+          }),
+        ],
+        $metadata: {},
+      };
+
+      dynamoDBClientMock.on(QueryCommand).resolves(queryCommandOutputMock);
+
+      const { aggregateIds } = await adapter.listAggregateIds({ eventStoreId });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.calls()).toHaveLength(1);
+      expect(dynamoDBClientMock.call(0).args[0].input).toStrictEqual({
+        ExpressionAttributeNames: {
+          '#eventStoreId': eventTableEventStoreIdKey,
+        },
+        ExpressionAttributeValues: marshall(
+          { ':eventStoreId': eventStoreId },
+          MARSHALL_OPTIONS,
+        ),
+        IndexName: eventTableInitialEventIndexName,
+        KeyConditionExpression: '#eventStoreId = :eventStoreId',
+        TableName: dynamoDBTableName,
+      });
+
+      // We have to serialize / deserialize because DynamoDB numbers are not regular numbers
+      expect(aggregateIds).toMatchObject([
+        { aggregateId, initialEventTimestamp: timestampA },
+        {
+          aggregateId: secondAggregateIdMock,
+          initialEventTimestamp: timestampB,
+        },
+      ]);
+    });
+
+    it('adds limit option', async () => {
+      await adapter.listAggregateIds({ eventStoreId }, { limit: 1 });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        Limit: 1,
+      });
+    });
+
+    it('filters aggregate ids with initial event date after timestamp', async () => {
+      await adapter.listAggregateIds(
+        { eventStoreId },
+        { initialEventAfter: timestampA },
+      );
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        ExpressionAttributeNames: {
+          '#timestamp': eventTableTimestampKey,
+        },
+        ExpressionAttributeValues: marshall(
+          { ':initialEventAfter': timestampA },
+          MARSHALL_OPTIONS,
+        ),
+        IndexName: eventTableInitialEventIndexName,
+        KeyConditionExpression:
+          '#eventStoreId = :eventStoreId and #timestamp >= :initialEventAfter',
+      });
+    });
+
+    it('filters aggregate ids with initial event date before timestamp', async () => {
+      await adapter.listAggregateIds(
+        { eventStoreId },
+        { initialEventBefore: timestampA },
+      );
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        ExpressionAttributeNames: {
+          '#timestamp': eventTableTimestampKey,
+        },
+        ExpressionAttributeValues: marshall(
+          { ':initialEventBefore': timestampA },
+          MARSHALL_OPTIONS,
+        ),
+        IndexName: eventTableInitialEventIndexName,
+        KeyConditionExpression:
+          '#eventStoreId = :eventStoreId and #timestamp <= :initialEventBefore',
+      });
+    });
+
+    it('filters aggregate ids with initial event date between timestamp', async () => {
+      await adapter.listAggregateIds(
+        { eventStoreId },
+        { initialEventAfter: timestampA, initialEventBefore: timestampB },
+      );
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        ExpressionAttributeNames: {
+          '#timestamp': eventTableTimestampKey,
+        },
+        ExpressionAttributeValues: marshall(
+          {
+            ':initialEventAfter': timestampA,
+            ':initialEventBefore': timestampB,
+          },
+          MARSHALL_OPTIONS,
+        ),
+        IndexName: eventTableInitialEventIndexName,
+        KeyConditionExpression:
+          '#eventStoreId = :eventStoreId and #timestamp between :initialEventAfter and :initialEventBefore',
+      });
+    });
+
+    it('adds reverse option', async () => {
+      await adapter.listAggregateIds({ eventStoreId }, { reverse: true });
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        ScanIndexForward: false,
+      });
+    });
+
+    it('returns a nextPageToken if query has LastEvaluatedKey', async () => {
+      const queryCommandOutputMock: QueryCommandOutput = {
+        Items: [
+          marshall({ aggregateId: prefixedAggregateId }, MARSHALL_OPTIONS),
+        ],
+        LastEvaluatedKey: lastEvaluatedKey,
+        $metadata: {},
+      };
+
+      dynamoDBClientMock.on(QueryCommand).resolves(queryCommandOutputMock);
+
+      const { nextPageToken } = await adapter.listAggregateIds(
+        { eventStoreId },
+        {
+          limit: 1,
+          initialEventAfter: timestampA,
+          initialEventBefore: timestampB,
+          reverse: true,
+        },
+      );
+
+      expect(JSON.parse(nextPageToken as string)).toStrictEqual({
+        limit: 1,
+        initialEventAfter: timestampA,
+        initialEventBefore: timestampB,
+        reverse: true,
+        lastEvaluatedKey,
+      });
+    });
+
+    it('applies next page token in the query', async () => {
+      await adapter.listAggregateIds(
+        { eventStoreId },
+        {
+          pageToken: JSON.stringify({
+            limit: 1,
+            initialEventAfter: timestampA,
+            initialEventBefore: timestampB,
+            reverse: true,
+            lastEvaluatedKey,
+          }),
+        },
+      );
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        Limit: 1,
+        ScanIndexForward: false,
+        ExclusiveStartKey: lastEvaluatedKey,
+        ExpressionAttributeNames: {
+          '#timestamp': eventTableTimestampKey,
+        },
+        ExpressionAttributeValues: marshall(
+          {
+            ':initialEventAfter': timestampA,
+            ':initialEventBefore': timestampB,
+          },
+          MARSHALL_OPTIONS,
+        ),
+        KeyConditionExpression:
+          '#eventStoreId = :eventStoreId and #timestamp between :initialEventAfter and :initialEventBefore',
+      });
+    });
+
+    it('uses the input limit even if the page token has an embedded limit', async () => {
+      await adapter.listAggregateIds(
+        { eventStoreId },
+        {
+          limit: 2,
+          initialEventAfter: timestampB,
+          initialEventBefore: timestampC,
+          reverse: false,
+          pageToken: JSON.stringify({
+            limit: 1,
+            initialEventAfter: timestampA,
+            initialEventBefore: timestampB,
+            reverse: true,
+            lastEvaluatedKey,
+          }),
+        },
+      );
+
+      // regularly check if vitest matchers are available (toHaveReceivedCommandWith)
+      // https://github.com/m-radzikowski/aws-sdk-client-mock/issues/139
+      expect(dynamoDBClientMock.call(0).args[0].input).toMatchObject({
+        Limit: 2,
+        ScanIndexForward: true,
+        ExclusiveStartKey: lastEvaluatedKey,
+        ExpressionAttributeNames: {
+          '#timestamp': eventTableTimestampKey,
+        },
+        ExpressionAttributeValues: marshall(
+          {
+            ':initialEventAfter': timestampB,
+            ':initialEventBefore': timestampC,
+          },
+          MARSHALL_OPTIONS,
+        ),
+        KeyConditionExpression:
+          '#eventStoreId = :eventStoreId and #timestamp between :initialEventAfter and :initialEventBefore',
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Description 🦫

In some circumstances, it is necessary to use a DynamoDB table for multiple purposes. In those scenarios, it is often not possible to control the names of the Partition and Sort keys or the index names.

This includes when following "Single Table Design" method, whereby the DynamoDB table may be used for Event Sourcing (i.e. the target for castore) as well as other purposes.

## Type of change 📝

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested? 🧑‍🔬

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added [unit tests](L531 in singleTableAdapter.unit.test.ts)

**Test Configuration**: 🔧

N/A

# Checklist: ✅

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas - I don't think this is required, but happy to add if required
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules - N/A