### PR TITLE
update(command-zod,event-type-zod): make compatible with zod v3/v4

### DIFF
--- a/packages/command-zod/package.json
+++ b/packages/command-zod/package.json
@@ -55,7 +55,7 @@
     "tsc-alias": "^1.8.7",
     "typescript": "^4.6.3",
     "vitest": "^0.26.2",
-    "zod": "^3.15.1"
+    "zod": "^4.1.11"
   },
   "maintainers": [
     "Thomas Aribart",
@@ -75,6 +75,6 @@
   },
   "peerDependencies": {
     "@castore/core": "*",
-    "zod": "^3.0.0"
+    "zod": "^3.25.0 || ^4.0.0"
   }
 }

--- a/packages/command-zod/src/command.ts
+++ b/packages/command-zod/src/command.ts
@@ -1,4 +1,5 @@
-import { z, ZodType } from 'zod';
+import type * as z3 from 'zod/v3';
+import type * as z4 from 'zod/v4/core';
 
 import {
   Command,
@@ -6,6 +7,11 @@ import {
   $Contravariant,
   OnEventAlreadyExistsCallback,
 } from '@castore/core';
+
+type ZodType = z3.ZodTypeAny | z4.$ZodType;
+type inferZodType<T extends ZodType> = T extends z3.ZodTypeAny
+  ? z3.infer<T>
+  : z4.infer<T>;
 
 export class ZodCommand<
   COMMAND_ID extends string = string,
@@ -18,13 +24,13 @@ export class ZodCommand<
   INPUT = $Contravariant<
     INPUT_SCHEMA,
     ZodType,
-    INPUT_SCHEMA extends ZodType ? z.infer<INPUT_SCHEMA> : never
+    INPUT_SCHEMA extends ZodType ? inferZodType<INPUT_SCHEMA> : never
   >,
   OUTPUT_SCHEMA extends ZodType | undefined = ZodType | undefined,
   OUTPUT = $Contravariant<
     OUTPUT_SCHEMA,
     ZodType,
-    OUTPUT_SCHEMA extends ZodType ? z.infer<OUTPUT_SCHEMA> : never
+    OUTPUT_SCHEMA extends ZodType ? inferZodType<OUTPUT_SCHEMA> : never
   >,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   CONTEXT extends any[] = any[],

--- a/packages/event-type-zod/package.json
+++ b/packages/event-type-zod/package.json
@@ -55,7 +55,7 @@
     "tsc-alias": "^1.8.7",
     "typescript": "^4.6.3",
     "vitest": "^0.26.2",
-    "zod": "^3.15.1"
+    "zod": "^4.1.11"
   },
   "maintainers": [
     "Thomas Aribart",
@@ -75,6 +75,6 @@
   },
   "peerDependencies": {
     "@castore/core": "*",
-    "zod": "^3.0.0"
+    "zod": "^3.25.0 || ^4.0.0"
   }
 }

--- a/packages/event-type-zod/src/eventType.ts
+++ b/packages/event-type-zod/src/eventType.ts
@@ -1,6 +1,12 @@
-import type { z, ZodType } from 'zod';
+import type * as z3 from 'zod/v3';
+import type * as z4 from 'zod/v4/core';
 
 import { EventType } from '@castore/core';
+
+type ZodType = z3.ZodTypeAny | z4.$ZodType;
+type inferZodType<T extends ZodType> = T extends z3.ZodTypeAny
+  ? z3.infer<T>
+  : z4.infer<T>;
 
 export class ZodEventType<
   TYPE extends string = string,
@@ -10,7 +16,7 @@ export class ZodEventType<
       ? unknown
       : never
     : PAYLOAD_SCHEMA extends ZodType
-    ? z.infer<PAYLOAD_SCHEMA>
+    ? inferZodType<PAYLOAD_SCHEMA>
     : never,
   METADATA_SCHEMA extends ZodType | undefined = ZodType | undefined,
   METADATA = ZodType extends METADATA_SCHEMA
@@ -18,7 +24,7 @@ export class ZodEventType<
       ? unknown
       : never
     : METADATA_SCHEMA extends ZodType
-    ? z.infer<METADATA_SCHEMA>
+    ? inferZodType<METADATA_SCHEMA>
     : never,
 > extends EventType<TYPE, PAYLOAD, METADATA> {
   payloadSchema?: PAYLOAD_SCHEMA;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6068,7 +6068,7 @@ __metadata:
     tsc-alias: ^1.8.7
     typescript: ^4.6.3
     vitest: ^0.26.2
-    zod: ^3.15.1
+    zod: ^4.1.11
   peerDependencies:
     "@castore/core": "*"
     zod: ^3.0.0
@@ -6418,10 +6418,10 @@ __metadata:
     tsc-alias: ^1.8.7
     typescript: ^4.6.3
     vitest: ^0.26.2
-    zod: ^3.15.1
+    zod: ^4.1.11
   peerDependencies:
     "@castore/core": "*"
-    zod: ^3.0.0
+    zod: ^3.25.0 || ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -28266,10 +28266,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.15.1":
-  version: 3.15.1
-  resolution: "zod@npm:3.15.1"
-  checksum: d1ceec91b1b19fe26233c2e6be7625c6d5937c6c667ce23ff7d59948eb1239a24819227c615096a5e6a6377a17fc2df3720e8d613d2176dc482c0a1e8d02e1e2
+"zod@npm:^4.1.11":
+  version: 4.1.11
+  resolution: "zod@npm:4.1.11"
+  checksum: 022d59f85ebe054835fbcdc96a93c01479a64321104f846cb5644812c91e00d17ae3479f823956ec9b04e4351dd32841e1f12c567e81bc43f6e21ef5cc02ce3c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description 🦫

This PR adds compatibility with both Zod v3 and Zod v4 to command-zod and event-type-zod. Not all users will be able to upgrade to Zod v4 immediately, so keeping compatibility with both versions is important.

I believe this is the cleanest way to support both versions at the same time, following the instructions from [Zod's guide for library authors on "How to support Zod 3 and Zod 4 simultaneously?"](https://zod.dev/library-authors?id=how-to-support-zod-3-and-zod-4-simultaneously).

Fixes #197

> [!IMPORTANT]
> This change requires a version of Zod >= 3.25.0. Unfortunately, neither v3 nor v4 will compile with the typescript version currently included by castore, so for this PR to work, typescript must be updated as well. Feel free to cherry-pick this change into your [mass upgrade](https://github.com/castore-dev/castore/pull/199) PR, or alternatively I can bump typescript in this PR.

## Type of change 📝

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested? 🧑‍🔬

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: 🔧
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist: ✅

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules