### PR TITLE
feat: add snapshot

### DIFF
--- a/packages/core/src/eventStore/eventStore.fixtures.test.ts
+++ b/packages/core/src/eventStore/eventStore.fixtures.test.ts
@@ -5,6 +5,11 @@ import { EventType, EventTypeDetail } from '~/event/eventType';
 import { GroupedEvent } from '~/event/groupedEvent';
 import { EventStorageAdapter } from '~/eventStorageAdapter';
 import { EventStore } from '~/eventStore';
+import {
+  cleanUpLastSnapshot,
+  createShouldSaveForRecurentSnapshots,
+  SnapshotStorageAdapter,
+} from '~/snapshot';
 
 export const pushEventMock = vi.fn();
 export const pushEventGroupMock = vi.fn();
@@ -65,12 +70,16 @@ export const pikachuCaughtEvent: PokemonEventDetails = {
   type: 'POKEMON_CAUGHT',
   timestamp: '2023',
 };
-export const pikachuLeveledUpEvent: PokemonEventDetails = {
+export const getPikachuLeveledUpEvent = (
+  version: number,
+): PokemonEventDetails => ({
   aggregateId: pikachuId,
-  version: 3,
+  version,
   type: 'POKEMON_LEVELED_UP',
   timestamp: '2024',
-};
+});
+export const pikachuLeveledUpEvent = getPikachuLeveledUpEvent(3);
+
 export const pikachuEventsMocks = [
   pikachuAppearedEvent,
   pikachuCaughtEvent,
@@ -115,4 +124,68 @@ export const pokemonsEventStore = new EventStore({
   eventTypes: [pokemonAppearedEvent, pokemonCaughtEvent, pokemonLeveledUpEvent],
   reducer: pokemonsReducer,
   eventStorageAdapter: eventStorageAdapterMock,
+});
+
+export const getSnapshotMock = vi.fn();
+export const saveSnapshotMock = vi.fn();
+export const deleteSnapshotMock = vi.fn();
+
+export const snapshotStorageAdapter: SnapshotStorageAdapter = {
+  getSnapshot: getSnapshotMock,
+  saveSnapshot: saveSnapshotMock,
+  deleteSnapshot: deleteSnapshotMock,
+};
+
+export const pikachuMultipleLevelUpEvents1Mocks = [
+  getPikachuLeveledUpEvent(4),
+  getPikachuLeveledUpEvent(5),
+];
+export const pikachuMultipleLevelUpEvents2Mocks = [
+  getPikachuLeveledUpEvent(6),
+  getPikachuLeveledUpEvent(7),
+  getPikachuLeveledUpEvent(8),
+  getPikachuLeveledUpEvent(9),
+  getPikachuLeveledUpEvent(10),
+];
+export const pikachuCompleteEventsMocks = [
+  ...pikachuEventsMocks,
+  ...pikachuMultipleLevelUpEvents1Mocks,
+  ...pikachuMultipleLevelUpEvents2Mocks,
+];
+
+export const snapshotV5 = {
+  aggregate: {
+    aggregateId: pikachuId,
+    version: 5,
+    name: 'Pikachu',
+    level: 45,
+    status: 'caught',
+  },
+  reducerVersion: 'v1.0.0',
+  eventStoreId: 'POKEMONS',
+};
+
+export const snapshotV10 = {
+  aggregate: {
+    aggregateId: pikachuId,
+    version: 10,
+    name: 'Pikachu',
+    level: 50,
+    status: 'caught',
+  },
+  reducerVersion: 'v1.0.0',
+  eventStoreId: 'POKEMONS',
+};
+
+export const pokemonsEventStoreWithSnapshot = new EventStore({
+  eventStoreId: 'POKEMONS',
+  eventTypes: [pokemonAppearedEvent, pokemonCaughtEvent, pokemonLeveledUpEvent],
+  reducer: pokemonsReducer,
+  eventStorageAdapter: eventStorageAdapterMock,
+  snapshotConfig: {
+    currentReducerVersion: 'v1.0.0',
+    shouldSaveSnapshot: createShouldSaveForRecurentSnapshots(5),
+    cleanUpAfterSnapshotSave: cleanUpLastSnapshot,
+  },
+  snapshotStorageAdapter,
 });

--- a/packages/core/src/eventStore/eventStore.ts
+++ b/packages/core/src/eventStore/eventStore.ts
@@ -4,11 +4,12 @@ import type { EventDetail } from '~/event/eventDetail';
 import type { EventType, EventTypeDetails } from '~/event/eventType';
 import { GroupedEvent } from '~/event/groupedEvent';
 import type { EventStorageAdapter } from '~/eventStorageAdapter';
+import { SnapshotConfig, Snapshot, SnapshotStorageAdapter } from '~/snapshot';
 import type { $Contravariant } from '~/utils';
 
 import { AggregateNotFoundError } from './errors/aggregateNotFound';
 import { UndefinedEventStorageAdapterError } from './errors/undefinedEventStorageAdapter';
-import type {
+import {
   AggregateIdsLister,
   EventPusher,
   OnEventPushed,
@@ -20,6 +21,8 @@ import type {
   AggregateGetter,
   AggregateSimulator,
   Reducer,
+  AggregateAsSnapshotSaver,
+  SnapshotGetter,
 } from './types';
 
 export class EventStore<
@@ -139,6 +142,11 @@ export class EventStore<
   eventStorageAdapter?: EventStorageAdapter;
   getEventStorageAdapter: () => EventStorageAdapter;
 
+  snapshotConfig?: SnapshotConfig<AGGREGATE, $AGGREGATE>;
+  snapshotStorageAdapter?: SnapshotStorageAdapter<AGGREGATE, $AGGREGATE>;
+  getSnapshot: SnapshotGetter<AGGREGATE>;
+  saveAggregateAsSnapshot: AggregateAsSnapshotSaver<$AGGREGATE>;
+
   constructor({
     eventStoreId,
     eventTypes,
@@ -149,6 +157,8 @@ export class EventStore<
     }),
     onEventPushed,
     eventStorageAdapter,
+    snapshotConfig,
+    snapshotStorageAdapter,
   }: {
     eventStoreId: EVENT_STORE_ID;
     eventTypes: EVENT_TYPES;
@@ -156,6 +166,8 @@ export class EventStore<
     simulateSideEffect?: SideEffectsSimulator<EVENT_DETAILS, $EVENT_DETAILS>;
     onEventPushed?: OnEventPushed<$EVENT_DETAILS, $AGGREGATE>;
     eventStorageAdapter?: EventStorageAdapter;
+    snapshotConfig?: SnapshotConfig<AGGREGATE, $AGGREGATE>;
+    snapshotStorageAdapter?: SnapshotStorageAdapter<AGGREGATE, $AGGREGATE>;
   }) {
     this.eventStoreId = eventStoreId;
     this.eventTypes = eventTypes;
@@ -163,6 +175,8 @@ export class EventStore<
     this.simulateSideEffect = simulateSideEffect;
     this.onEventPushed = onEventPushed;
     this.eventStorageAdapter = eventStorageAdapter;
+    this.snapshotConfig = snapshotConfig;
+    this.snapshotStorageAdapter = snapshotStorageAdapter;
 
     this.getEventStorageAdapter = () => {
       if (this.eventStorageAdapter === undefined) {
@@ -239,15 +253,116 @@ export class EventStore<
     this.buildAggregate = (eventDetails, aggregate) =>
       eventDetails.reduce(this.reducer, aggregate) as AGGREGATE | undefined;
 
-    this.getAggregate = async (aggregateId, { maxVersion } = {}) => {
-      const { events } = await this.getEvents(aggregateId, { maxVersion });
+    this.getSnapshot = async (aggregateId, { maxVersion } = {}) => {
+      if (this.snapshotConfig === undefined) {
+        throw new Error(
+          `snapshotConfig is required in eventStore "${this.eventStoreId}" to use getAggregateFromSnapshot`,
+        );
+      }
+      if (this.snapshotStorageAdapter === undefined) {
+        throw new Error(
+          `EventStore "${this.eventStoreId}" has a snapshotConfig but no snapshotStorageAdapter.`,
+        );
+      }
+      const latestSnapshot = await this.snapshotStorageAdapter.getSnapshot({
+        aggregateId,
+        aggregateMaxVersion: maxVersion,
+        eventStoreId: this.eventStoreId,
+        reducerVersion:
+          this.snapshotConfig.migrateSnapshotReducerVersion === undefined
+            ? this.snapshotConfig.currentReducerVersion
+            : undefined,
+      });
+
+      if (latestSnapshot === undefined) {
+        return undefined;
+      }
+
+      if (
+        latestSnapshot.reducerVersion ===
+        this.snapshotConfig.currentReducerVersion
+      ) {
+        return latestSnapshot;
+      }
+
+      if (this.snapshotConfig.migrateSnapshotReducerVersion === undefined) {
+        throw new Error(
+          `snapshotStorageAdapter of eventStore "${this.eventStoreId}" returned a snapshot with a reducerVersion ("${latestSnapshot.reducerVersion}") different from the currentReducerVersion ("${this.snapshotConfig.currentReducerVersion}"). This is not supposed to happen`,
+        );
+      }
+
+      return this.snapshotConfig.migrateSnapshotReducerVersion(
+        latestSnapshot as unknown as Snapshot<$AGGREGATE>,
+      );
+    };
+
+    this.saveAggregateAsSnapshot = async (aggregate, previousSnapshot) => {
+      if (this.snapshotConfig === undefined) {
+        throw new Error(
+          `snapshotConfig is required in eventStore "${this.eventStoreId}" to use saveAggregateAsSnapshot`,
+        );
+      }
+      if (this.snapshotStorageAdapter === undefined) {
+        throw new Error(
+          `EventStore "${this.eventStoreId}" has a snapshotConfig but no snapshotStorageAdapter.`,
+        );
+      }
+
+      const snapshot = {
+        aggregate,
+        eventStoreId: this.eventStoreId,
+        reducerVersion: this.snapshotConfig.currentReducerVersion,
+      };
+
+      await this.snapshotStorageAdapter.saveSnapshot(snapshot);
+
+      await this.snapshotConfig.cleanUpAfterSnapshotSave?.({
+        latestSnapshot: snapshot,
+        previousSnapshot,
+        snapshotStorageAdapter: this
+          .snapshotStorageAdapter as unknown as SnapshotStorageAdapter<
+          $AGGREGATE,
+          $AGGREGATE
+        >,
+      });
+    };
+
+    this.getAggregate = async (
+      aggregateId,
+      { maxVersion, useSnapshot } = {},
+    ) => {
+      const snapshot =
+        useSnapshot === true
+          ? await this.getSnapshot(aggregateId, { maxVersion })
+          : undefined;
+      const minVersion =
+        snapshot !== undefined ? snapshot.aggregate.version + 1 : undefined;
+
+      const { events } = await this.getEvents(aggregateId, {
+        maxVersion,
+        minVersion,
+      });
 
       const aggregate = this.buildAggregate(
         events as unknown as $EVENT_DETAILS[],
-        undefined,
+        snapshot?.aggregate as unknown as $AGGREGATE | undefined,
       );
 
-      const lastEvent = events[events.length - 1];
+      if (
+        aggregate !== undefined &&
+        this.snapshotConfig?.shouldSaveSnapshot({
+          aggregate: aggregate as unknown as $AGGREGATE | undefined,
+          previousSnapshot: snapshot as Snapshot<$AGGREGATE> | undefined,
+        }) === true
+      ) {
+        await this.saveAggregateAsSnapshot(
+          aggregate as unknown as $AGGREGATE,
+          snapshot as Snapshot<$AGGREGATE> | undefined,
+        );
+      }
+
+      const lastEvent =
+        events.length > 0 ? events[events.length - 1] : undefined;
 
       return { aggregate, events, lastEvent };
     };

--- a/packages/core/src/eventStore/eventStore.unit.test.ts
+++ b/packages/core/src/eventStore/eventStore.unit.test.ts
@@ -22,6 +22,15 @@ import {
   groupEventMock,
   eventStorageAdapterMock,
   PokemonEventDetails,
+  pokemonsEventStoreWithSnapshot,
+  getSnapshotMock,
+  snapshotV5,
+  saveSnapshotMock,
+  deleteSnapshotMock,
+  snapshotV10,
+  pikachuMultipleLevelUpEventsMocks,
+  pikachuCompleteEventsMocks,
+  pikachuMultipleLevelUpEvents2Mocks,
 } from './eventStore.fixtures.test';
 
 describe('event store', () => {
@@ -51,6 +60,10 @@ describe('event store', () => {
         'getAggregate',
         'getExistingAggregate',
         'simulateAggregate',
+        'snapshotConfig',
+        'snapshotStorageAdapter',
+        'getSnapshot',
+        'saveAggregateAsSnapshot',
       ]),
     );
 
@@ -390,6 +403,91 @@ describe('event store', () => {
       );
 
       expect(response).toStrictEqual({ aggregateIds: [pikachuId] });
+    });
+  });
+
+  describe('snapshots', () => {
+    beforeEach(() => {
+      getEventsMock.mockResolvedValue({
+        events: pikachuMultipleLevelUpEvents2Mocks,
+      });
+      getSnapshotMock.mockClear();
+      getSnapshotMock.mockResolvedValue(snapshotV5);
+      saveSnapshotMock.mockClear();
+      deleteSnapshotMock.mockClear();
+    });
+    describe('getAggregate', () => {
+      it('gets the latest snapshot', async () => {
+        await pokemonsEventStoreWithSnapshot.getAggregate(pikachuId, {
+          useSnapshot: true,
+        });
+
+        expect(getSnapshotMock).toHaveBeenCalledOnce();
+        expect(getSnapshotMock).toHaveBeenCalledWith({
+          aggregateId: pikachuId,
+          eventStoreId: 'POKEMONS',
+          reducerVersion: 'v1.0.0',
+        });
+      });
+
+      it('gets events from the latest snapshot', async () => {
+        await pokemonsEventStoreWithSnapshot.getAggregate(pikachuId, {
+          useSnapshot: true,
+        });
+
+        expect(getEventsMock).toHaveBeenCalledTimes(1);
+        expect(getEventsMock).toHaveBeenCalledWith(
+          pikachuId,
+          { eventStoreId: pokemonsEventStore.eventStoreId },
+          {
+            minVersion: 6,
+          },
+        );
+      });
+
+      it('saves a new snapshot', async () => {
+        await pokemonsEventStoreWithSnapshot.getAggregate(pikachuId, {
+          useSnapshot: true,
+        });
+
+        expect(saveSnapshotMock).toHaveBeenCalledTimes(1);
+        expect(saveSnapshotMock).toHaveBeenCalledWith(snapshotV10);
+      });
+
+      it('deletes the old snapshot', async () => {
+        await pokemonsEventStoreWithSnapshot.getAggregate(pikachuId, {
+          useSnapshot: true,
+        });
+
+        expect(deleteSnapshotMock).toHaveBeenCalledTimes(1);
+        expect(deleteSnapshotMock).toHaveBeenCalledWith({
+          aggregateId: 'pikachuId',
+          aggregateVersion: 5,
+          eventStoreId: 'POKEMONS',
+          reducerVersion: 'v1.0.0',
+        });
+      });
+
+      it('returns the aggregate from the snapshot and the rest of the events', async () => {
+        const response = await pokemonsEventStoreWithSnapshot.getAggregate(
+          pikachuId,
+          {
+            useSnapshot: true,
+          },
+        );
+
+        expect(response).toStrictEqual({
+          aggregate: pikachuCompleteEventsMocks.reduce(
+            pokemonsReducer,
+            undefined as unknown as PokemonAggregate,
+          ),
+          events: pikachuMultipleLevelUpEvents2Mocks, // events are incomplete
+          lastEvent:
+            pikachuMultipleLevelUpEvents2Mocks[
+              pikachuMultipleLevelUpEvents2Mocks.length - 1
+            ],
+        });
+      });
     });
   });
 });

--- a/packages/core/src/eventStore/types.ts
+++ b/packages/core/src/eventStore/types.ts
@@ -6,6 +6,7 @@ import type {
   ListAggregateIdsOptions,
   ListAggregateIdsOutput,
 } from '~/eventStorageAdapter';
+import { Snapshot } from '~/snapshot';
 import type { $Contravariant } from '~/utils';
 
 export type Reducer<
@@ -104,6 +105,7 @@ export type OnEventPushed<$EVENT_DETAILS, $AGGREGATE> = (props: {
 
 export type GetAggregateOptions = {
   maxVersion?: number;
+  useSnapshot?: boolean;
 };
 
 export type AggregateGetter<
@@ -115,11 +117,21 @@ export type AggregateGetter<
   options?: GetAggregateOptions,
 ) => Promise<{
   aggregate: SHOULD_EXIST extends true ? AGGREGATE : AGGREGATE | undefined;
-  events: EVENT_DETAIL[];
+  events: EVENT_DETAIL[]; // ⚠️ with useSnapshot = true, the events are incomplete
   lastEvent: SHOULD_EXIST extends true
     ? EVENT_DETAIL
     : EVENT_DETAIL | undefined;
 }>;
+
+export type SnapshotGetter<AGGREGATE extends Aggregate> = (
+  aggregateId: string,
+  options?: GetAggregateOptions,
+) => Promise<Snapshot<AGGREGATE> | undefined>;
+
+export type AggregateAsSnapshotSaver<AGGREGATE extends Aggregate> = (
+  aggregate: AGGREGATE,
+  prevSnapshot?: Snapshot<AGGREGATE>,
+) => Promise<void>;
 
 export type SimulationOptions = { simulationDate?: string };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,3 +72,12 @@ export type {
   EventStoreNotificationMessage,
   EventStoreStateCarryingMessage,
 } from './messaging';
+export {
+  cleanUpLastSnapshot,
+  createShouldSaveForRecurentSnapshots,
+} from './snapshot';
+export type {
+  Snapshot,
+  SnapshotConfig,
+  SnapshotStorageAdapter,
+} from './snapshot';

--- a/packages/core/src/snapshot/defaultSnapshotConfig.ts
+++ b/packages/core/src/snapshot/defaultSnapshotConfig.ts
@@ -1,0 +1,40 @@
+import { Aggregate } from '~/aggregate';
+
+import { Snapshot, SnapshotStorageAdapter } from './snapshotStorageAdapter';
+
+export const createShouldSaveForRecurentSnapshots =
+  (versionGap: number) =>
+  <AGGREGATE extends Aggregate>({
+    aggregate,
+  }: {
+    aggregate?: AGGREGATE;
+  }): boolean => {
+    if (aggregate === undefined) {
+      return false;
+    }
+    if (aggregate.version % versionGap === 0) {
+      return true;
+    }
+
+    return false;
+  };
+
+export const cleanUpLastSnapshot = async <AGGREGATE extends Aggregate>({
+  previousSnapshot,
+  snapshotStorageAdapter,
+}: {
+  latestSnapshot: Snapshot<AGGREGATE>;
+  previousSnapshot?: Snapshot<AGGREGATE>;
+  snapshotStorageAdapter: SnapshotStorageAdapter<AGGREGATE, AGGREGATE>;
+}): Promise<void> => {
+  if (previousSnapshot === undefined) {
+    return;
+  }
+
+  return snapshotStorageAdapter.deleteSnapshot({
+    aggregateId: previousSnapshot.aggregate.aggregateId,
+    aggregateVersion: previousSnapshot.aggregate.version,
+    eventStoreId: previousSnapshot.eventStoreId,
+    reducerVersion: previousSnapshot.reducerVersion,
+  });
+};

--- a/packages/core/src/snapshot/defaultSnapshotConfig.unit.test.ts
+++ b/packages/core/src/snapshot/defaultSnapshotConfig.unit.test.ts
@@ -1,0 +1,101 @@
+import { Aggregate } from '~/aggregate';
+import {
+  cleanUpLastSnapshot,
+  createShouldSaveForRecurentSnapshots,
+} from '~/snapshot/defaultSnapshotConfig';
+import { SnapshotStorageAdapter } from '~/snapshot/snapshotStorageAdapter';
+
+describe('Default Snapshot Config', () => {
+  const aggregateId = 'aggregateId';
+  describe('createShouldSaveForRecurentSnapshots', () => {
+    it('return false if aggregate is not defined', () => {
+      expect(
+        createShouldSaveForRecurentSnapshots(0)({
+          aggregate: undefined,
+        }),
+      ).toBe(false);
+    });
+
+    it.each`
+      aggregateVersion | versionGap | shouldSaveSnapshot
+      ${1}             | ${2}       | ${false}
+      ${2}             | ${2}       | ${true}
+      ${3}             | ${2}       | ${false}
+      ${4}             | ${2}       | ${true}
+      ${1}             | ${10}      | ${false}
+      ${9}             | ${10}      | ${false}
+      ${10}            | ${10}      | ${true}
+      ${11}            | ${10}      | ${false}
+      ${20}            | ${10}      | ${true}
+      ${100}           | ${10}      | ${true}
+      ${1}             | ${15}      | ${false}
+      ${14}            | ${15}      | ${false}
+      ${15}            | ${15}      | ${true}
+      ${16}            | ${15}      | ${false}
+      ${30}            | ${15}      | ${true}
+      ${90}            | ${15}      | ${true}
+    `(
+      'returns $shouldSaveSnapshot if aggregate version is $aggregateVersion for versionGap = $versionGap',
+      ({
+        aggregateVersion,
+        versionGap,
+        shouldSaveSnapshot,
+      }: {
+        aggregateVersion: number;
+        versionGap: number;
+        shouldSaveSnapshot: boolean;
+      }) => {
+        expect(
+          createShouldSaveForRecurentSnapshots(versionGap)({
+            aggregate: { version: aggregateVersion, aggregateId },
+          }),
+        ).toBe(shouldSaveSnapshot);
+      },
+    );
+  });
+  describe('cleanUpLastSnapshot', () => {
+    const deleteSnapshot = vi.fn();
+    const snapshotStorageAdapter = {
+      deleteSnapshot,
+    } as unknown as SnapshotStorageAdapter<Aggregate, Aggregate>;
+
+    const latestSnapshot = {
+      aggregate: {
+        aggregateId: 'aggregateId',
+        version: 20,
+      },
+      reducerVersion: 'v1',
+      eventStoreId: 'eventStoreId',
+    };
+
+    const previousSnapshot = {
+      aggregate: {
+        aggregateId: 'aggregateId',
+        version: 10,
+      },
+      reducerVersion: 'v1',
+      eventStoreId: 'eventStoreId',
+    };
+
+    it('does nothing if previous snapshot if undefined', async () => {
+      await cleanUpLastSnapshot({ latestSnapshot, snapshotStorageAdapter });
+
+      expect(deleteSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('delete the previous snapshot if defined', async () => {
+      await cleanUpLastSnapshot({
+        latestSnapshot,
+        previousSnapshot,
+        snapshotStorageAdapter,
+      });
+
+      expect(deleteSnapshot).toHaveBeenCalledWith({
+        aggregateId: 'aggregateId',
+        aggregateVersion: 10,
+        reducerVersion: 'v1',
+        eventStoreId: 'eventStoreId',
+      });
+    });
+  });
+});

--- a/packages/core/src/snapshot/index.ts
+++ b/packages/core/src/snapshot/index.ts
@@ -1,0 +1,3 @@
+export * from './snapshotStorageAdapter';
+export * from './snapshotConfig';
+export * from './defaultSnapshotConfig';

--- a/packages/core/src/snapshot/snapshotConfig.ts
+++ b/packages/core/src/snapshot/snapshotConfig.ts
@@ -1,0 +1,30 @@
+import { Aggregate } from '~/aggregate';
+
+import { Snapshot, SnapshotStorageAdapter } from './snapshotStorageAdapter';
+
+export interface SnapshotConfig<
+  AGGREGATE extends Aggregate,
+  $AGGREGATE extends Aggregate,
+> {
+  currentReducerVersion: string;
+
+  shouldSaveSnapshot: (args: {
+    aggregate?: $AGGREGATE;
+    previousSnapshot?: Snapshot<$AGGREGATE>;
+  }) => boolean;
+
+  // Optional - if provided, this function will be called when a snapshot is loaded but its reducer version doesn't match the current reducer version
+  // if not provided, the snapshot will be ignored and the aggregate will be rebuilt from events
+  migrateSnapshotReducerVersion?: (
+    snapshot: Snapshot<$AGGREGATE>,
+  ) =>
+    | Promise<Snapshot<AGGREGATE> | undefined>
+    | Snapshot<AGGREGATE>
+    | undefined;
+
+  cleanUpAfterSnapshotSave?: (args: {
+    latestSnapshot: Snapshot<$AGGREGATE>;
+    previousSnapshot?: Snapshot<$AGGREGATE>;
+    snapshotStorageAdapter: SnapshotStorageAdapter<$AGGREGATE, $AGGREGATE>;
+  }) => Promise<void> | void;
+}

--- a/packages/core/src/snapshot/snapshotStorageAdapter.ts
+++ b/packages/core/src/snapshot/snapshotStorageAdapter.ts
@@ -1,0 +1,45 @@
+import { Aggregate } from '~/aggregate';
+
+export type Snapshot<AGGREGATE extends Aggregate> = {
+  aggregate: AGGREGATE;
+  reducerVersion: string;
+  eventStoreId: string;
+};
+
+export interface SnapshotStorageAdapter<
+  AGGREGATE extends Aggregate = Aggregate,
+  $AGGREGATE = Aggregate,
+> {
+  getSnapshot: ({
+    aggregateId,
+    eventStoreId,
+    reducerVersion,
+  }: {
+    aggregateId: string;
+    eventStoreId: string;
+    aggregateMaxVersion?: number; // Optional - if provided, get the latest snapshot with a version bellow max version
+    reducerVersion?: string; // Optional - if provided, get the latest snapshot build with this reducer version
+  }) => Promise<Snapshot<AGGREGATE> | undefined>;
+
+  saveSnapshot: ({
+    aggregate,
+    eventStoreId,
+    reducerVersion,
+  }: {
+    aggregate: $AGGREGATE;
+    reducerVersion: string;
+    eventStoreId: string;
+  }) => Promise<void>;
+
+  deleteSnapshot: ({
+    aggregateId,
+    aggregateVersion,
+    eventStoreId,
+    reducerVersion,
+  }: {
+    aggregateId: string;
+    aggregateVersion: number;
+    eventStoreId: string;
+    reducerVersion: string;
+  }) => Promise<void>;
+}


### PR DESCRIPTION
# Description 🦫

Add snapshot capabilities : 
```ts
export const pokemonsEventStoreWithSnapshot = new EventStore({
  eventStoreId: 'POKEMONS',
  eventTypes: [pokemonAppearedEvent, pokemonCaughtEvent, pokemonLeveledUpEvent],
  reducer: pokemonsReducer,
  eventStorageAdapter: eventStorageAdapterMock,
  snapshotConfig: {
    currentReducerVersion: 'v1.0.0',
    shouldSaveSnapshot: createShouldSaveForRecurentSnapshots(5),
    cleanUpAfterSnapshotSave: cleanUpLastSnapshot,
  },
  snapshotStorageAdapter,
});
```
consult `packages/core/src/eventStore/eventStore.unit.test.ts` and `packages/core/src/eventStore/eventStore.fixtures.test.ts` to know more. 

Fixes https://github.com/castore-dev/castore/issues/181

Replaces https://github.com/castore-dev/castore/pull/174

### TODO 🚧 

- [ ] Challenge `getAggregate` signature cf Question part
- [ ] Propagate changes to `ConnectedEventStore`
- [ ] Add `DynamoDbSnapshotStorageAdapter`
- [ ] Add documentation


### Questions ⁉️

I'm not sure about `getAggregate` signature with snapshot. Currently `getAggregate` returns `{ aggregate, events, lastEvent };`. But with snapshot returning `events` and `lastEvent` is either cost expensive or misleading.

Here are some propositions:

- include snapshot capabilities to current `getAggregate`, determine if snapshot must be use if `snapshotConfig` is defined. Return partials `events` (only those fetched) and `lastEvent` only if one event have been fetched additionally to a snapshot
- *(✅ currently implemented)* include snapshot capabilities to current `getAggregate`, add an explicit `useSnapshot` option, determine if snapshot must be use if `useSnapshot` is `true`. Return partials `events` (only those fetched) and `lastEvent` only if one event have been fetched additionally to a snapshot
- include snapshot capabilities to `getAggregate` but with signature **BREAKING CHANGE**. Determine if snapshot must be use if `snapshotConfig` is defined. Return only `aggregate`. Add a new explicit `getEventsAndAggregate` corresponding to current `getAggregate` without snapshot capabilities
- include snapshot capabilities to a new explicit `getAggregateWithSnapshot`. Determine if snapshot must be use if `snapshotConfig` is defined. Return only `aggregate`. Let `getAggregate` as it is.

## Type of change 📝

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested? 🧑‍🔬

🚧 

- [x] Test unit
- [ ] Test linked on real projet

**Test Configuration**: 🔧
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist: ✅

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules